### PR TITLE
Rebuild distribution when any javascript file changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-dist:
+dist: *.js
 	webpack scalardl-web-client-sdk.js --output-library Scalar -o dist/scalardl-web-client-sdk.bundle.js
 clean:
 	rm -r dist/


### PR DESCRIPTION
We can use the current Makefile to rebuild the distribution because make always determines that dist/ is updated. We have to set its dependency such that any javascript file changing can make it rebuild.