### PR TITLE
Use .npmignore to ignore some files when publish to NPM registry

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+test/
+example/
+Makefile


### PR DESCRIPTION
We can exclude following unnecessary files/folders when we publish the package to NPM registry:
- test/
- example/
- Makefile