### PR TITLE
Automatically publish package to NPM register

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,9 +69,27 @@ jobs:
 
       - store_artifacts:
           path: ~/scalardl-web-client-sdk/test/test-reports
+  deploy:
+    docker:
+      - image: circleci/node
+    steps:
+      - checkout
+      - run:
+          name: Authenticate with registry
+          command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc
+      - run:
+          name: Publish package
+          command: npm publish --access public
+
 workflows:
   version: 2
   build-deploy:
     jobs:
       - build:
           context: "scalar"
+      - deploy:
+          requires:
+            - build
+          filters:
+            branches:
+              only: master

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@scalar-labs/scalardl-web-client-sdk",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "jsrsasign": "^8.0.20"
   },
   "name": "@scalar-labs/scalardl-web-client-sdk",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "The web client SDK for Scalar DL",
   "main": "scalardl-web-client-sdk.js",
   "author": "Scalar, Inc.",


### PR DESCRIPTION
This PR adds a new job `deploy` into CircleCI. The job will try to publish this SDK to the official NPM registry (registry.npmjs.org).

## When the NPM package will be published?
Every time the master branch is updated

## What do we have to config?
The owner has to configure a new environment `NPM_TOKEN` with the value of its NPM Auth token