### PR TITLE
Use CircleCI context to read the environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,6 +88,7 @@ workflows:
       - build:
           context: "scalar"
       - deploy:
+          context: "scalar"
           requires:
             - build
           filters:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@scalar-labs/scalardl-web-client-sdk",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "jsrsasign": "^8.0.20"
   },
   "name": "@scalar-labs/scalardl-web-client-sdk",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "The web client SDK for Scalar DL",
   "main": "scalardl-web-client-sdk.js",
   "author": "Scalar, Inc.",


### PR DESCRIPTION
The environment variable `NPM_TOKEN` used in .circleci/config.yml is set as a context.
To use we have to declare context in the .circleci/config.yml.