### PR TITLE
Ignore some unnecessary folders from NPM packing and fix NPM audit

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,5 @@
 example/
 Makefile
 .eslintrc.json
+test/
+.circleci/

--- a/package-lock.json
+++ b/package-lock.json
@@ -3260,9 +3260,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
       "dev": true
     },
     "log-symbols": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@scalar-labs/scalardl-web-client-sdk",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "jsrsasign": "^8.0.20"
   },
   "name": "@scalar-labs/scalardl-web-client-sdk",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "The web client SDK for Scalar DL",
   "main": "scalardl-web-client-sdk.js",
   "author": "Scalar, Inc.",


### PR DESCRIPTION
The PR provides minor enhancements
- Don't pack `test/` and `.circleci/` into NPM package when publishing to the registry
- Fix a vulnerable dependency `lodash` according to `npm audit`