### PR TITLE
README.md for linearizable ledger validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,21 @@ const status = response.getCode();
 const proof = response.getProof();
 ```
 
+#### Validate an asset linearizably
+The default ledger validation in a Auditor-enabled Scalar DL network is non-linearizable; i.e., there might be cases where Ledger and Auditor look inconsistent temporarily.
+Scalar DL supports linearizable ledger validation.
+To use it, we can configure the properties as follows
+```javascript
+{
+    'scalar.dl.client.auditor.enabled': true,
+    ...
+    'scalar.dl.client.auditor.linearizable_validation.enabled': true,
+    'scalar.dl.client.auditor.linearizable_validation.contract_id': '<choose a contract ID>',
+}
+```
+and, register the [ValidateLedger](https://github.com/scalar-labs/scalardl-java-client-sdk/blob/master/src/main/java/com/scalar/dl/client/contract/ValidateLedger.java) contract as the contract ID we specified in the properties.
+Then, the ClientService.validateLedger function can provide linearizable ledger validation.
+
 ### Runtime error
 Error thrown by the client present a status code.
 ```javascript


### PR DESCRIPTION
This PR updates README.md for linearizable ledger validation.

The change is the same as
https://github.com/scalar-labs/scalardl-node-client-sdk/pull/54