### PR TITLE
Prettify JavaScript files

### DIFF
--- a/indexdb.js
+++ b/indexdb.js
@@ -33,13 +33,14 @@ class ClientServiceWithIndexedDb {
       );
       const cryptoKey = clientProperties.getPrivateKeyCryptoKey();
       const pem = clientProperties.getPrivateKeyPem();
-      const keyId = `${clientProperties.getCertHolderId()}_` +
-                `${clientProperties.getCertVersion()}`;
+      const keyId =
+        `${clientProperties.getCertHolderId()}_` +
+        `${clientProperties.getCertVersion()}`;
 
       let key;
       try {
         if (cryptoKey || pem) {
-          key = cryptoKey || await toCryptoKeyFromJwk(toJwkFromPkcs1(pem));
+          key = cryptoKey || (await toCryptoKeyFromJwk(toJwkFromPkcs1(pem)));
           await db.keystore.put({id: keyId, key: key});
         } else {
           const item = await db.keystore.get(keyId);
@@ -75,8 +76,9 @@ class ClientServiceWithIndexedDb {
             ClientPropertiesField.CERT_VERSION,
           ], // cert_holder_id and cert_version are required
       );
-      const keyId = `${clientProperties.getCertHolderId()}_` +
-                `${clientProperties.getCertVersion()}`;
+      const keyId =
+        `${clientProperties.getCertHolderId()}_` +
+        `${clientProperties.getCertVersion()}`;
 
       try {
         await db.keystore.delete(keyId);
@@ -96,10 +98,10 @@ class ClientServiceWithIndexedDb {
 }
 
 /** @description Indicates the private key is not found in indexedDB */
-class IndexedDbKeyNotFoundError extends Error { }
+class IndexedDbKeyNotFoundError extends Error {}
 
 /** @description Indicates fail indexedDB operation */
-class IndexedDbOperationError extends Error { }
+class IndexedDbOperationError extends Error {}
 
 module.exports = {
   ClientServiceWithIndexedDb,

--- a/karma.auditor.conf.js
+++ b/karma.auditor.conf.js
@@ -1,9 +1,7 @@
 module.exports = function(config) {
   config.set({
     frameworks: ['mocha', 'chai'],
-    files: [
-      'test/integration_auditor.test.js',
-    ],
+    files: ['test/integration_auditor.test.js'],
     reporters: ['progress'],
     preprocessors: {
       'test/*.test.js': ['webpack'],

--- a/lib/keyutil.js
+++ b/lib/keyutil.js
@@ -6,14 +6,14 @@ const jsrsasign = require('jsrsasign');
  */
 async function toCryptoKeyFromJwk(jwk) {
   return window.crypto.subtle.importKey(
-    'jwk',
-    jwk,
-    {
-      name: 'ECDSA',
-      namedCurve: 'P-256',
-    },
-    false, // extractable is false (which means unextractable)
-    ['sign'],
+      'jwk',
+      jwk,
+      {
+        name: 'ECDSA',
+        namedCurve: 'P-256',
+      },
+      false, // extractable is false (which means unextractable)
+      ['sign'],
   );
 }
 
@@ -22,10 +22,15 @@ async function toCryptoKeyFromJwk(jwk) {
  * @return {Object}
  */
 function toJwkFromPkcs1(pkcs1) {
-  pkcs1 = pkcs1.replace('-----BEGIN EC PRIVATE KEY-----', '')
+  pkcs1 = pkcs1
+      .replace('-----BEGIN EC PRIVATE KEY-----', '')
       .replace('-----END EC PRIVATE KEY-----', '')
       .replace(/\r\n/g, '');
-  const key = jsrsasign.KEYUTIL.getKey(jsrsasign.b64utohex(pkcs1), null, 'pkcs5prv');
+  const key = jsrsasign.KEYUTIL.getKey(
+      jsrsasign.b64utohex(pkcs1),
+      null,
+      'pkcs5prv',
+  );
 
   return jsrsasign.KEYUTIL.getJWKFromKey(key);
 }

--- a/scalardl-web-client-sdk.js
+++ b/scalardl-web-client-sdk.js
@@ -38,27 +38,34 @@ class ClientService extends ClientServiceBase {
     const host = clientProperties.getServerHost();
     const auditorHost = clientProperties.getAuditorHost();
     const tlsEnabled = clientProperties.getTlsEnabled();
-    const ledgerClientServiceURL =
-      `${tlsEnabled ? 'https' : 'http'}://${host}:${clientProperties.getServerPort()}`;
-    const ledgerPriviledgedClientServiceURL =
-      `${tlsEnabled ? 'https' : 'http'}://${host}:${clientProperties.getServerPrivilegedPort()}`;
-    const auditorClientServiceURL =
-      `${tlsEnabled ? 'https' : 'http'}://${auditorHost}:${clientProperties.getAuditorPort()}`;
-    const auditorPriviledgedClientServiceURL =
-      `${tlsEnabled ? 'https' : 'http'}://${auditorHost}:${clientProperties.getAuditorPrivilegedPort()}`;
+    const ledgerClientServiceURL = `${
+      tlsEnabled ? 'https' : 'http'
+    }://${host}:${clientProperties.getServerPort()}`;
+    const ledgerPriviledgedClientServiceURL = `${
+      tlsEnabled ? 'https' : 'http'
+    }://${host}:${clientProperties.getServerPrivilegedPort()}`;
+    const auditorClientServiceURL = `${
+      tlsEnabled ? 'https' : 'http'
+    }://${auditorHost}:${clientProperties.getAuditorPort()}`;
+    const auditorPriviledgedClientServiceURL = `${
+      tlsEnabled ? 'https' : 'http'
+    }://${auditorHost}:${clientProperties.getAuditorPrivilegedPort()}`;
 
     const services = {
       ledgerClient: new LedgerClient(ledgerClientServiceURL),
-      ledgerPrivileged: new LedgerPrivilegedClient(ledgerPriviledgedClientServiceURL),
+      ledgerPrivileged: new LedgerPrivilegedClient(
+          ledgerPriviledgedClientServiceURL,
+      ),
       auditorClient: new AuditorClient(auditorClientServiceURL),
-      auditorPrivileged: new AuditorPrivilegedClient(auditorPriviledgedClientServiceURL),
+      auditorPrivileged: new AuditorPrivilegedClient(
+          auditorPriviledgedClientServiceURL,
+      ),
       signerFactory: new SignerFactory(),
     };
 
     const metadata = {};
     if (clientProperties.getAuthorizationCredential()) {
-      metadata.Authorization =
-          clientProperties.getAuthorizationCredential();
+      metadata.Authorization = clientProperties.getAuthorizationCredential();
     }
     super(services, protobuf, properties, metadata);
   }

--- a/signer.js
+++ b/signer.js
@@ -1,7 +1,4 @@
-const {
-  toCryptoKeyFromJwk,
-  toJwkFromPkcs1,
-} = require('./lib/keyutil');
+const {toCryptoKeyFromJwk, toJwkFromPkcs1} = require('./lib/keyutil');
 
 /** @description The signer based on Web Crypto API */
 class WebCryptoSigner {
@@ -15,7 +12,7 @@ class WebCryptoSigner {
       this.key = key;
     } else {
       throw new Error(
-          'key type should be either String (PEM) or Object (CryptoKey)'
+          'key type should be either String (PEM) or Object (CryptoKey)',
       );
     }
   }
@@ -39,7 +36,8 @@ class WebCryptoSigner {
       }
     }
 
-    const algorithm = { // EcdsaParams
+    const algorithm = {
+      // EcdsaParams
       name: 'ECDSA',
       hash: 'SHA-256',
     };
@@ -85,9 +83,9 @@ class WebCryptoSigner {
    * ]
    */
   _P1363ToDer(sig) {
-    const signature = Array
-        .from(sig, (x) => ('00' + x.toString(16)).slice(-2))
-        .join('');
+    const signature = Array.from(sig, (x) =>
+      ('00' + x.toString(16)).slice(-2),
+    ).join('');
     let r = signature.substr(0, signature.length / 2);
     let s = signature.substr(signature.length / 2);
     r = r.replace(/^(00)+/, '');
@@ -97,9 +95,10 @@ class WebCryptoSigner {
     const rString = `02${(r.length / 2).toString(16).padStart(2, '0')}${r}`;
     const sString = `02${(s.length / 2).toString(16).padStart(2, '0')}${s}`;
     const derSig = `30${((rString.length + sString.length) / 2)
-        .toString(16).padStart(2, '0')}${rString}${sString}`;
-    return new Uint8Array( derSig.match(/[\da-f]{2}/gi).map(
-        (h) => parseInt(h, 16)),
+        .toString(16)
+        .padStart(2, '0')}${rString}${sString}`;
+    return new Uint8Array(
+        derSig.match(/[\da-f]{2}/gi).map((h) => parseInt(h, 16)),
     );
   }
 }

--- a/test/client_service_with_indexeddb.test.js
+++ b/test/client_service_with_indexeddb.test.js
@@ -40,13 +40,11 @@ describe('ClientServiceWithIndexedDb', function() {
       };
 
       const clientService = await new ClientServiceWithIndexedDb(
-          new ClientService(properties)
+          new ClientService(properties),
       );
       const signature = await window.crypto.subtle.sign(
           {name: 'ECDSA', hash: 'SHA-256'},
-          clientService.properties[
-              'scalar.dl.client.private_key_cryptokey'
-          ],
+          clientService.properties['scalar.dl.client.private_key_cryptokey'],
           new ArrayBuffer([1, 2, 3]),
       );
       const verified = await window.crypto.subtle.verify(
@@ -57,8 +55,7 @@ describe('ClientServiceWithIndexedDb', function() {
       );
 
       chai.assert.equal(true, verified);
-    }
-    );
+    });
 
     it('should work to store pem', async function() {
       const certHolderId = `${new Date().getTime()}`;
@@ -69,12 +66,14 @@ describe('ClientServiceWithIndexedDb', function() {
         'scalar.dl.client.server.privileged_port': 50052,
         'scalar.dl.client.cert_holder_id': certHolderId,
         'scalar.dl.client.cert_version': certVersion,
-        'scalar.dl.client.private_key_pem': '-----BEGIN EC PRIVATE KEY-----\n' +
+        'scalar.dl.client.private_key_pem':
+          '-----BEGIN EC PRIVATE KEY-----\n' +
           'MHcCAQEEICcJGMEw3dyXUGFu/5a36HqY0ynZi9gLUfKgYWMYgr/IoAoGCCqGSM49\n' +
           'AwEHoUQDQgAEBGuhqumyh7BVNqcNKAQQipDGooUpURve2dO66pQCgjtSfu7lJV20\n' +
           'XYWdrgo0Y3eXEhvK0lsURO9N0nrPiQWT4A==\n' +
           '-----END EC PRIVATE KEY-----\n',
-        'scalar.dl.client.cert_pem': '-----BEGIN CERTIFICATE-----\n' +
+        'scalar.dl.client.cert_pem':
+          '-----BEGIN CERTIFICATE-----\n' +
           'MIICizCCAjKgAwIBAgIUMEUDTdWsQpftFkqs6bCd6U++4nEwCgYIKoZIzj0EAwIw\n' +
           'bzELMAkGA1UEBhMCSlAxDjAMBgNVBAgTBVRva3lvMQ4wDAYDVQQHEwVUb2t5bzEf\n' +
           'MB0GA1UEChMWU2FtcGxlIEludGVybWVkaWF0ZSBDQTEfMB0GA1UEAxMWU2FtcGxl\n' +
@@ -93,16 +92,17 @@ describe('ClientServiceWithIndexedDb', function() {
       };
       const keyId = `${certHolderId}_${certVersion}`;
 
-      const before = await db.keystore.get(keyId); ;
+      const before = await db.keystore.get(keyId);
       const clientService = await new ClientServiceWithIndexedDb(
-          new ClientService(properties)
+          new ClientService(properties),
       );
-      const after = await db.keystore.get(keyId); ;
+      const after = await db.keystore.get(keyId);
 
       chai.assert.equal(undefined, before);
       chai.assert.notEqual(undefined, after);
       await chai.expect(clientService.registerCertificate()).to.not.be.rejected;
-      await chai.expect(clientService.validateLedger('foo', 0, 1)).to.not.be.rejected;
+      await chai.expect(clientService.validateLedger('foo', 0, 1)).to.not.be
+          .rejected;
       await chai.expect(clientService.validateLedger('foo')).to.not.be.rejected;
     });
 
@@ -120,11 +120,9 @@ describe('ClientServiceWithIndexedDb', function() {
       };
       const keyId = `${certHolderId}_${certVersion}`;
 
-      const before = await db.keystore.get(keyId); ;
-      await new ClientServiceWithIndexedDb(
-          new ClientService(properties)
-      );
-      const after = await db.keystore.get(keyId); ;
+      const before = await db.keystore.get(keyId);
+      await new ClientServiceWithIndexedDb(new ClientService(properties));
+      const after = await db.keystore.get(keyId);
 
       chai.assert.equal(undefined, before);
       chai.assert.notEqual(undefined, after);
@@ -141,9 +139,9 @@ describe('ClientServiceWithIndexedDb', function() {
         'scalar.dl.client.cert_version': certVersion,
       };
 
-      await chai.expect(new ClientServiceWithIndexedDb(
-          new ClientService(properties)
-      )).to.be.rejectedWith(IndexedDbKeyNotFoundError);
+      await chai
+          .expect(new ClientServiceWithIndexedDb(new ClientService(properties)))
+          .to.be.rejectedWith(IndexedDbKeyNotFoundError);
     });
   });
 
@@ -163,7 +161,7 @@ describe('ClientServiceWithIndexedDb', function() {
       };
 
       const clientService = await new ClientServiceWithIndexedDb(
-          new ClientService(properties)
+          new ClientService(properties),
       );
       const before = await db.keystore.get(keyId);
       await clientService.deleteIndexedDb();

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -12,61 +12,64 @@ describe('ClientService', () => {
     // Make the test idempotent.
     'scalar.dl.client.cert_holder_id': `foo@${Date.now()}`,
 
-    'scalar.dl.client.private_key_pem': '-----BEGIN EC PRIVATE KEY-----\n' +
-    'MHcCAQEEICcJGMEw3dyXUGFu/5a36HqY0ynZi9gLUfKgYWMYgr/IoAoGCCqGSM49\n' +
-    'AwEHoUQDQgAEBGuhqumyh7BVNqcNKAQQipDGooUpURve2dO66pQCgjtSfu7lJV20\n' +
-    'XYWdrgo0Y3eXEhvK0lsURO9N0nrPiQWT4A==\n-----END EC PRIVATE KEY-----\n',
+    'scalar.dl.client.private_key_pem':
+      '-----BEGIN EC PRIVATE KEY-----\n' +
+      'MHcCAQEEICcJGMEw3dyXUGFu/5a36HqY0ynZi9gLUfKgYWMYgr/IoAoGCCqGSM49\n' +
+      'AwEHoUQDQgAEBGuhqumyh7BVNqcNKAQQipDGooUpURve2dO66pQCgjtSfu7lJV20\n' +
+      'XYWdrgo0Y3eXEhvK0lsURO9N0nrPiQWT4A==\n-----END EC PRIVATE KEY-----\n',
 
-    'scalar.dl.client.cert_pem': '-----BEGIN CERTIFICATE-----\n' +
-    'MIICizCCAjKgAwIBAgIUMEUDTdWsQpftFkqs6bCd6U++4nEwCgYIKoZIzj0EAwIw\n' +
-    'bzELMAkGA1UEBhMCSlAxDjAMBgNVBAgTBVRva3lvMQ4wDAYDVQQHEwVUb2t5bzEf\n' +
-    'MB0GA1UEChMWU2FtcGxlIEludGVybWVkaWF0ZSBDQTEfMB0GA1UEAxMWU2FtcGxl\n' +
-    'IEludGVybWVkaWF0ZSBDQTAeFw0xODA5MTAwODA3MDBaFw0yMTA5MDkwODA3MDBa\n' +
-    'MEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIEwpTb21lLVN0YXRlMSEwHwYDVQQKExhJ\n' +
-    'bnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNC\n' +
-    'AAQEa6Gq6bKHsFU2pw0oBBCKkMaihSlRG97Z07rqlAKCO1J+7uUlXbRdhZ2uCjRj\n' +
-    'd5cSG8rSWxRE703Ses+JBZPgo4HVMIHSMA4GA1UdDwEB/wQEAwIFoDATBgNVHSUE\n' +
-    'DDAKBggrBgEFBQcDAjAMBgNVHRMBAf8EAjAAMB0GA1UdDgQWBBRDd2MS9Ndo68PJ\n' +
-    'y9K/RNY6syZW0zAfBgNVHSMEGDAWgBR+Y+v8yByDNp39G7trYrTfZ0UjJzAxBggr\n' +
-    'BgEFBQcBAQQlMCMwIQYIKwYBBQUHMAGGFWh0dHA6Ly9sb2NhbGhvc3Q6ODg4OTAq\n' +
-    'BgNVHR8EIzAhMB+gHaAbhhlodHRwOi8vbG9jYWxob3N0Ojg4ODgvY3JsMAoGCCqG\n' +
-    'SM49BAMCA0cAMEQCIC/Bo4oNU6yHFLJeme5ApxoNdyu3rWyiqWPxJmJAr9L0AiBl\n' +
-    'Gc/v+yh4dHIDhCrimajTQAYOG9n0kajULI70Gg7TNw==\n-----END CERTIFICATE-----\n',
+    'scalar.dl.client.cert_pem':
+      '-----BEGIN CERTIFICATE-----\n' +
+      'MIICizCCAjKgAwIBAgIUMEUDTdWsQpftFkqs6bCd6U++4nEwCgYIKoZIzj0EAwIw\n' +
+      'bzELMAkGA1UEBhMCSlAxDjAMBgNVBAgTBVRva3lvMQ4wDAYDVQQHEwVUb2t5bzEf\n' +
+      'MB0GA1UEChMWU2FtcGxlIEludGVybWVkaWF0ZSBDQTEfMB0GA1UEAxMWU2FtcGxl\n' +
+      'IEludGVybWVkaWF0ZSBDQTAeFw0xODA5MTAwODA3MDBaFw0yMTA5MDkwODA3MDBa\n' +
+      'MEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIEwpTb21lLVN0YXRlMSEwHwYDVQQKExhJ\n' +
+      'bnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNC\n' +
+      'AAQEa6Gq6bKHsFU2pw0oBBCKkMaihSlRG97Z07rqlAKCO1J+7uUlXbRdhZ2uCjRj\n' +
+      'd5cSG8rSWxRE703Ses+JBZPgo4HVMIHSMA4GA1UdDwEB/wQEAwIFoDATBgNVHSUE\n' +
+      'DDAKBggrBgEFBQcDAjAMBgNVHRMBAf8EAjAAMB0GA1UdDgQWBBRDd2MS9Ndo68PJ\n' +
+      'y9K/RNY6syZW0zAfBgNVHSMEGDAWgBR+Y+v8yByDNp39G7trYrTfZ0UjJzAxBggr\n' +
+      'BgEFBQcBAQQlMCMwIQYIKwYBBQUHMAGGFWh0dHA6Ly9sb2NhbGhvc3Q6ODg4OTAq\n' +
+      'BgNVHR8EIzAhMB+gHaAbhhlodHRwOi8vbG9jYWxob3N0Ojg4ODgvY3JsMAoGCCqG\n' +
+      'SM49BAMCA0cAMEQCIC/Bo4oNU6yHFLJeme5ApxoNdyu3rWyiqWPxJmJAr9L0AiBl\n' +
+      'Gc/v+yh4dHIDhCrimajTQAYOG9n0kajULI70Gg7TNw==\n' +
+      '-----END CERTIFICATE-----\n',
 
     'scalar.dl.client.cert_version': 1,
     'scalar.dl.client.tls.enabled': false,
 
-    'scalar.dl.client.tls.ca_root_cert_pem': '-----BEGIN CERTIFICATE-----\n' +
-    'MIIE/jCCAuagAwIBAgIJAJO8tpVEEORLMA0GCSqGSIb3DQEBCwUAMBQxEjAQBgNV\n' +
-    'BAMMCWxvY2FsaG9zdDAeFw0xOTAzMTMxMDUyMTFaFw0yMDAzMTIxMDUyMTFaMBQx\n' +
-    'EjAQBgNVBAMMCWxvY2FsaG9zdDCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoC\n' +
-    'ggIBAKFeFSrXRh5jA+OodMPw0XFO4sd4G9wYERlxgCjDmd9eC+loLpjGwRwwO7os\n' +
-    '/+rhW+Cg/NGhNn64xCmS/JtZf91SBD1QfQ4wk4094sAUIHsztaWtZTATl6aIy0BN\n' +
-    '21A0ueFgVQGehwO1FdRKtS7X+45YV2vMMK/UQ69VSCwY82olBRgWp45TXLUmWVgC\n' +
-    'UAJkE/V2Ch8WLyKpCggtaxYmn8YfzA1X20QDK1b2IW4YPDcPapQLtU6wqIjrXX1E\n' +
-    'w992GgfERm//I14QEyu+qIPafsniDGYxiR6HK8nqeR70QcGHt+Qql24xyjwWHEA/\n' +
-    '43pn3jjrNVRhiVAD8tkVyRmfWjIngksRHPwEh3jG34gshOi9xAaID+mx2AWhThsk\n' +
-    'XbuqSxHckPlvgWHugZmFOwKZAgU5/gpnWR7oHPOSYffhGwmc/+SK/SQ4UDeTFI2c\n' +
-    '40Xw22P8CWbIq4gKi66kSvuFbLSeKQIRMJd50hf7kw3SqnkqEaeRXy5jBovut7CU\n' +
-    'nwcgGPceYmWhKxhkg5urzk+CQZENf+9+pVvArOQemn9bMuaBPwtwXE42+fktQpQ2\n' +
-    'PG3k7ryVL5R0jhuVNXf9ioU2z1ONQ2IdsuFtCKnozfVBAhy9bPfm120rTV/UBOCD\n' +
-    'zcmfRnv081lG9BN/KtZBo7hfFH/ZD2542yVRvibRIIdPWIkTAgMBAAGjUzBRMB0G\n' +
-    'A1UdDgQWBBQ61fQAtAgd7sM/NDtIX4D8GSA/8DAfBgNVHSMEGDAWgBQ61fQAtAgd\n' +
-    '7sM/NDtIX4D8GSA/8DAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IC\n' +
-    'AQCaYh1bxlj9Impoq3rmFHl5/9Fb2o2H2Ne8VjTHb8eSoHuLwXdWzKnw6UhiCaN4\n' +
-    'EZgrsqq1L2Tc8Y+eqT4gz3uDLc5Cj29HHC/suZezIo3lgyZ/A6stYQXE5Gy8e+to\n' +
-    'Qhmf4u8RMZ8zt6i355un6mTJxJq7JxoVqpECf5tg6pMdOUzbcKLTmN6i50jH/PSO\n' +
-    'NQsJhiSJg3caNdWviob+UwEuUineMF/X08dB3gphZ7kmfDeRjmONALMXS1uvPwk2\n' +
-    '3s8S45LmxETx+tcJSvckKRC9JaQf6dgHfKAWHpkIqvLKyqy9Dmvg2RSJi3kI9oaj\n' +
-    'dm64zc6CAsqVaPvoMfWIN7JZq9jvzc8msGiilfhiYoc+M3jvnmM81FuGbAw7Utq4\n' +
-    'uuHtpCcpbxRMChD4WdlrPeBONyBKp+RRWTGfBY1GW5aGWVp/cbcpIc2RSgnZcrxb\n' +
-    '6ef2iTMtUjRd76JlkobTyvgo0GKdLgnr8c711I2YNp+TabKIKZOEvw2X+oGbfxBN\n' +
-    '1WvRB5YJo2rzwZj0fSvN9IwT9TGxSZIo5zcaQuwLEmDZBJShgXN5Ya71Vag1AP2i\n' +
-    'mOwUJRvfTVPWg+wtF2JQwaPpK0+Kb7oCq9tl3PUW40FRgqWV1Tgp6Co/U1W/1BU6\n' +
-    '02Vmic/M/HmRMwWuX1PyVOVr8Mjyj+OMF1JsmdR5eL5Mtg==\n' +
-    '-----END CERTIFICATE-----\n',
+    'scalar.dl.client.tls.ca_root_cert_pem':
+      '-----BEGIN CERTIFICATE-----\n' +
+      'MIIE/jCCAuagAwIBAgIJAJO8tpVEEORLMA0GCSqGSIb3DQEBCwUAMBQxEjAQBgNV\n' +
+      'BAMMCWxvY2FsaG9zdDAeFw0xOTAzMTMxMDUyMTFaFw0yMDAzMTIxMDUyMTFaMBQx\n' +
+      'EjAQBgNVBAMMCWxvY2FsaG9zdDCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoC\n' +
+      'ggIBAKFeFSrXRh5jA+OodMPw0XFO4sd4G9wYERlxgCjDmd9eC+loLpjGwRwwO7os\n' +
+      '/+rhW+Cg/NGhNn64xCmS/JtZf91SBD1QfQ4wk4094sAUIHsztaWtZTATl6aIy0BN\n' +
+      '21A0ueFgVQGehwO1FdRKtS7X+45YV2vMMK/UQ69VSCwY82olBRgWp45TXLUmWVgC\n' +
+      'UAJkE/V2Ch8WLyKpCggtaxYmn8YfzA1X20QDK1b2IW4YPDcPapQLtU6wqIjrXX1E\n' +
+      'w992GgfERm//I14QEyu+qIPafsniDGYxiR6HK8nqeR70QcGHt+Qql24xyjwWHEA/\n' +
+      '43pn3jjrNVRhiVAD8tkVyRmfWjIngksRHPwEh3jG34gshOi9xAaID+mx2AWhThsk\n' +
+      'XbuqSxHckPlvgWHugZmFOwKZAgU5/gpnWR7oHPOSYffhGwmc/+SK/SQ4UDeTFI2c\n' +
+      '40Xw22P8CWbIq4gKi66kSvuFbLSeKQIRMJd50hf7kw3SqnkqEaeRXy5jBovut7CU\n' +
+      'nwcgGPceYmWhKxhkg5urzk+CQZENf+9+pVvArOQemn9bMuaBPwtwXE42+fktQpQ2\n' +
+      'PG3k7ryVL5R0jhuVNXf9ioU2z1ONQ2IdsuFtCKnozfVBAhy9bPfm120rTV/UBOCD\n' +
+      'zcmfRnv081lG9BN/KtZBo7hfFH/ZD2542yVRvibRIIdPWIkTAgMBAAGjUzBRMB0G\n' +
+      'A1UdDgQWBBQ61fQAtAgd7sM/NDtIX4D8GSA/8DAfBgNVHSMEGDAWgBQ61fQAtAgd\n' +
+      '7sM/NDtIX4D8GSA/8DAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IC\n' +
+      'AQCaYh1bxlj9Impoq3rmFHl5/9Fb2o2H2Ne8VjTHb8eSoHuLwXdWzKnw6UhiCaN4\n' +
+      'EZgrsqq1L2Tc8Y+eqT4gz3uDLc5Cj29HHC/suZezIo3lgyZ/A6stYQXE5Gy8e+to\n' +
+      'Qhmf4u8RMZ8zt6i355un6mTJxJq7JxoVqpECf5tg6pMdOUzbcKLTmN6i50jH/PSO\n' +
+      'NQsJhiSJg3caNdWviob+UwEuUineMF/X08dB3gphZ7kmfDeRjmONALMXS1uvPwk2\n' +
+      '3s8S45LmxETx+tcJSvckKRC9JaQf6dgHfKAWHpkIqvLKyqy9Dmvg2RSJi3kI9oaj\n' +
+      'dm64zc6CAsqVaPvoMfWIN7JZq9jvzc8msGiilfhiYoc+M3jvnmM81FuGbAw7Utq4\n' +
+      'uuHtpCcpbxRMChD4WdlrPeBONyBKp+RRWTGfBY1GW5aGWVp/cbcpIc2RSgnZcrxb\n' +
+      '6ef2iTMtUjRd76JlkobTyvgo0GKdLgnr8c711I2YNp+TabKIKZOEvw2X+oGbfxBN\n' +
+      '1WvRB5YJo2rzwZj0fSvN9IwT9TGxSZIo5zcaQuwLEmDZBJShgXN5Ya71Vag1AP2i\n' +
+      'mOwUJRvfTVPWg+wtF2JQwaPpK0+Kb7oCq9tl3PUW40FRgqWV1Tgp6Co/U1W/1BU6\n' +
+      '02Vmic/M/HmRMwWuX1PyVOVr8Mjyj+OMF1JsmdR5eL5Mtg==\n' +
+      '-----END CERTIFICATE-----\n',
   };
-
 
   describe('Integration test on ClientService', async () => {
     const mockedFunctionId = 'TestFunction';
@@ -83,9 +86,11 @@ describe('ClientService', () => {
       properties: 'bar',
     };
     const mockedByteContract = new Uint8Array(
-        require('arraybuffer-loader!./StateUpdater.class'));
+        require('arraybuffer-loader!./StateUpdater.class'),
+    );
     const mockedByteFunction = new Uint8Array(
-        require('arraybuffer-loader!./TestFunction.class'));
+        require('arraybuffer-loader!./TestFunction.class'),
+    );
     const clientService = new ClientService(properties);
     describe('registerCertificate', () => {
       it('should be successful', async () => {
@@ -96,9 +101,11 @@ describe('ClientService', () => {
     });
     describe('registerFunction', () => {
       it('should return 200 when correct inputs are specified', async () => {
-        const response = await clientService.registerFunction(mockedFunctionId,
+        const response = await clientService.registerFunction(
+            mockedFunctionId,
             mockedFunctionName,
-            mockedByteFunction);
+            mockedByteFunction,
+        );
         assert.deepEqual(response, undefined);
       });
     });
@@ -107,7 +114,9 @@ describe('ClientService', () => {
         const response = await clientService.registerContract(
             mockedContractId,
             mockedContractName,
-            mockedByteContract, contractProperty);
+            mockedByteContract,
+            contractProperty,
+        );
         assert.deepEqual(response, undefined);
       });
     });
@@ -122,17 +131,23 @@ describe('ClientService', () => {
       );
     });
     describe('executeContract', () => {
-      it('should work as expected when executing a registered contract',
+      it(
+          'should work as expected ' + 'when executing a registered contract',
           async () => {
             const response = await clientService.executeContract(
                 mockedContractId,
-                mockedContractArgument, {});
+                mockedContractArgument,
+                {},
+            );
             const contractResult = response.getResult();
             assert.equal(contractResult.asset_id, mockedAssetId);
             assert.equal(contractResult.state, mockedState);
-            assert.equal(contractResult.properties,
-                contractProperty.properties);
-          });
+            assert.equal(
+                contractResult.properties,
+                contractProperty.properties,
+            );
+          },
+      );
       it(
           'should work as expected ' +
           'when executing a registered contract and function',
@@ -151,21 +166,36 @@ describe('ClientService', () => {
                 contractArgumentWithFunction,
                 functionArgument,
             );
-            assert.equal(response.getResult().state,
-                contractArgumentWithFunction.state);
-          });
+            assert.equal(
+                response.getResult().state,
+                contractArgumentWithFunction.state,
+            );
+          },
+      );
     });
     describe('validateLedger', () => {
-      it('should return 200 when correct asset id and age are specified', async () => {
-        const response = await clientService.validateLedger(mockedAssetId, 0, 1);
-        assert.equal(response.getCode(), 200);
-      });
-      it('should return 200 even only correct asset id is specified', async () => {
-        const response = await clientService.validateLedger(mockedAssetId);
-        assert.equal(response.getCode(), 200);
-      });
+      it(
+          'should return 200 ' + 'when correct asset id and age are specified',
+          async () => {
+            const response = await clientService.validateLedger(
+                mockedAssetId,
+                0,
+                1,
+            );
+            assert.equal(response.getCode(), 200);
+          },
+      );
+      it(
+          'should return 200 ' + 'even only correct asset id is specified',
+          async () => {
+            const response = await clientService.validateLedger(mockedAssetId);
+            assert.equal(response.getCode(), 200);
+          },
+      );
       it('should return 409 when incorrect asset id is specified', async () => {
-        const response = await clientService.validateLedger('incorrect_asset_id');
+        const response = await clientService.validateLedger(
+            'incorrect_asset_id',
+        );
         assert.equal(response.getCode(), 409);
       });
     });
@@ -181,7 +211,8 @@ describe('ClientService', () => {
       const certVersion = 1;
       const keyId = `${holderId}_${certVersion}`;
       const {toCryptoKeyFromJwk, toJwkFromPkcs1} = require('../lib/keyutil');
-      const pem = '-----BEGIN EC PRIVATE KEY-----\n' +
+      const pem =
+        '-----BEGIN EC PRIVATE KEY-----\n' +
         'MHcCAQEEICcJGMEw3dyXUGFu/5a36HqY0ynZi9gLUfKgYWMYgr/IoAoGCCqGSM49\n' +
         'AwEHoUQDQgAEBGuhqumyh7BVNqcNKAQQipDGooUpURve2dO66pQCgjtSfu7lJV20\n' +
         'XYWdrgo0Y3eXEhvK0lsURO9N0nrPiQWT4A==\n' +
@@ -194,7 +225,8 @@ describe('ClientService', () => {
         'scalar.dl.client.server.privileged_port': 50052,
         'scalar.dl.client.cert_holder_id': holderId,
         'scalar.dl.client.cert_version': certVersion,
-        'scalar.dl.client.cert_pem': '-----BEGIN CERTIFICATE-----\n' +
+        'scalar.dl.client.cert_pem':
+          '-----BEGIN CERTIFICATE-----\n' +
           'MIICizCCAjKgAwIBAgIUMEUDTdWsQpftFkqs6bCd6U++4nEwCgYIKoZIzj0EAwIw\n' +
           'bzELMAkGA1UEBhMCSlAxDjAMBgNVBAgTBVRva3lvMQ4wDAYDVQQHEwVUb2t5bzEf\n' +
           'MB0GA1UEChMWU2FtcGxlIEludGVybWVkaWF0ZSBDQTEfMB0GA1UEAxMWU2FtcGxl\n' +
@@ -216,7 +248,11 @@ describe('ClientService', () => {
           new ClientService(properties),
       );
       await clientService.registerCertificate();
-      const response = await clientService.validateLedger('non_existing_asset', 0, 1);
+      const response = await clientService.validateLedger(
+          'non_existing_asset',
+          0,
+          1,
+      );
 
       assert.equal(StatusCode.ASSET_NOT_FOUND, response.getCode());
     });

--- a/test/integration_auditor.test.js
+++ b/test/integration_auditor.test.js
@@ -1,7 +1,5 @@
 describe('ClientService', () => {
-  const {
-    ClientService,
-  } = require('../scalardl-web-client-sdk.js');
+  const {ClientService} = require('../scalardl-web-client-sdk.js');
   const validateLedgerContractId = `validate-ledger${Date.now()}`;
   const properties = {
     'scalar.dl.client.server.host': '127.0.0.1',
@@ -19,59 +17,63 @@ describe('ClientService', () => {
     // Make the test idempotent.
     'scalar.dl.client.cert_holder_id': `foo@${Date.now()}`,
 
-    'scalar.dl.client.private_key_pem': '-----BEGIN EC PRIVATE KEY-----\n' +
-    'MHcCAQEEICcJGMEw3dyXUGFu/5a36HqY0ynZi9gLUfKgYWMYgr/IoAoGCCqGSM49\n' +
-    'AwEHoUQDQgAEBGuhqumyh7BVNqcNKAQQipDGooUpURve2dO66pQCgjtSfu7lJV20\n' +
-    'XYWdrgo0Y3eXEhvK0lsURO9N0nrPiQWT4A==\n-----END EC PRIVATE KEY-----\n',
+    'scalar.dl.client.private_key_pem':
+      '-----BEGIN EC PRIVATE KEY-----\n' +
+      'MHcCAQEEICcJGMEw3dyXUGFu/5a36HqY0ynZi9gLUfKgYWMYgr/IoAoGCCqGSM49\n' +
+      'AwEHoUQDQgAEBGuhqumyh7BVNqcNKAQQipDGooUpURve2dO66pQCgjtSfu7lJV20\n' +
+      'XYWdrgo0Y3eXEhvK0lsURO9N0nrPiQWT4A==\n-----END EC PRIVATE KEY-----\n',
 
-    'scalar.dl.client.cert_pem': '-----BEGIN CERTIFICATE-----\n' +
-    'MIICizCCAjKgAwIBAgIUMEUDTdWsQpftFkqs6bCd6U++4nEwCgYIKoZIzj0EAwIw\n' +
-    'bzELMAkGA1UEBhMCSlAxDjAMBgNVBAgTBVRva3lvMQ4wDAYDVQQHEwVUb2t5bzEf\n' +
-    'MB0GA1UEChMWU2FtcGxlIEludGVybWVkaWF0ZSBDQTEfMB0GA1UEAxMWU2FtcGxl\n' +
-    'IEludGVybWVkaWF0ZSBDQTAeFw0xODA5MTAwODA3MDBaFw0yMTA5MDkwODA3MDBa\n' +
-    'MEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIEwpTb21lLVN0YXRlMSEwHwYDVQQKExhJ\n' +
-    'bnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNC\n' +
-    'AAQEa6Gq6bKHsFU2pw0oBBCKkMaihSlRG97Z07rqlAKCO1J+7uUlXbRdhZ2uCjRj\n' +
-    'd5cSG8rSWxRE703Ses+JBZPgo4HVMIHSMA4GA1UdDwEB/wQEAwIFoDATBgNVHSUE\n' +
-    'DDAKBggrBgEFBQcDAjAMBgNVHRMBAf8EAjAAMB0GA1UdDgQWBBRDd2MS9Ndo68PJ\n' +
-    'y9K/RNY6syZW0zAfBgNVHSMEGDAWgBR+Y+v8yByDNp39G7trYrTfZ0UjJzAxBggr\n' +
-    'BgEFBQcBAQQlMCMwIQYIKwYBBQUHMAGGFWh0dHA6Ly9sb2NhbGhvc3Q6ODg4OTAq\n' +
-    'BgNVHR8EIzAhMB+gHaAbhhlodHRwOi8vbG9jYWxob3N0Ojg4ODgvY3JsMAoGCCqG\n' +
-    'SM49BAMCA0cAMEQCIC/Bo4oNU6yHFLJeme5ApxoNdyu3rWyiqWPxJmJAr9L0AiBl\n' +
-    'Gc/v+yh4dHIDhCrimajTQAYOG9n0kajULI70Gg7TNw==\n-----END CERTIFICATE-----\n',
+    'scalar.dl.client.cert_pem':
+      '-----BEGIN CERTIFICATE-----\n' +
+      'MIICizCCAjKgAwIBAgIUMEUDTdWsQpftFkqs6bCd6U++4nEwCgYIKoZIzj0EAwIw\n' +
+      'bzELMAkGA1UEBhMCSlAxDjAMBgNVBAgTBVRva3lvMQ4wDAYDVQQHEwVUb2t5bzEf\n' +
+      'MB0GA1UEChMWU2FtcGxlIEludGVybWVkaWF0ZSBDQTEfMB0GA1UEAxMWU2FtcGxl\n' +
+      'IEludGVybWVkaWF0ZSBDQTAeFw0xODA5MTAwODA3MDBaFw0yMTA5MDkwODA3MDBa\n' +
+      'MEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIEwpTb21lLVN0YXRlMSEwHwYDVQQKExhJ\n' +
+      'bnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNC\n' +
+      'AAQEa6Gq6bKHsFU2pw0oBBCKkMaihSlRG97Z07rqlAKCO1J+7uUlXbRdhZ2uCjRj\n' +
+      'd5cSG8rSWxRE703Ses+JBZPgo4HVMIHSMA4GA1UdDwEB/wQEAwIFoDATBgNVHSUE\n' +
+      'DDAKBggrBgEFBQcDAjAMBgNVHRMBAf8EAjAAMB0GA1UdDgQWBBRDd2MS9Ndo68PJ\n' +
+      'y9K/RNY6syZW0zAfBgNVHSMEGDAWgBR+Y+v8yByDNp39G7trYrTfZ0UjJzAxBggr\n' +
+      'BgEFBQcBAQQlMCMwIQYIKwYBBQUHMAGGFWh0dHA6Ly9sb2NhbGhvc3Q6ODg4OTAq\n' +
+      'BgNVHR8EIzAhMB+gHaAbhhlodHRwOi8vbG9jYWxob3N0Ojg4ODgvY3JsMAoGCCqG\n' +
+      'SM49BAMCA0cAMEQCIC/Bo4oNU6yHFLJeme5ApxoNdyu3rWyiqWPxJmJAr9L0AiBl\n' +
+      'Gc/v+yh4dHIDhCrimajTQAYOG9n0kajULI70Gg7TNw==\n' +
+      '-----END CERTIFICATE-----\n',
 
     'scalar.dl.client.cert_version': 1,
     'scalar.dl.client.tls.enabled': false,
 
-    'scalar.dl.client.tls.ca_root_cert_pem': '-----BEGIN CERTIFICATE-----\n' +
-    'MIIE/jCCAuagAwIBAgIJAJO8tpVEEORLMA0GCSqGSIb3DQEBCwUAMBQxEjAQBgNV\n' +
-    'BAMMCWxvY2FsaG9zdDAeFw0xOTAzMTMxMDUyMTFaFw0yMDAzMTIxMDUyMTFaMBQx\n' +
-    'EjAQBgNVBAMMCWxvY2FsaG9zdDCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoC\n' +
-    'ggIBAKFeFSrXRh5jA+OodMPw0XFO4sd4G9wYERlxgCjDmd9eC+loLpjGwRwwO7os\n' +
-    '/+rhW+Cg/NGhNn64xCmS/JtZf91SBD1QfQ4wk4094sAUIHsztaWtZTATl6aIy0BN\n' +
-    '21A0ueFgVQGehwO1FdRKtS7X+45YV2vMMK/UQ69VSCwY82olBRgWp45TXLUmWVgC\n' +
-    'UAJkE/V2Ch8WLyKpCggtaxYmn8YfzA1X20QDK1b2IW4YPDcPapQLtU6wqIjrXX1E\n' +
-    'w992GgfERm//I14QEyu+qIPafsniDGYxiR6HK8nqeR70QcGHt+Qql24xyjwWHEA/\n' +
-    '43pn3jjrNVRhiVAD8tkVyRmfWjIngksRHPwEh3jG34gshOi9xAaID+mx2AWhThsk\n' +
-    'XbuqSxHckPlvgWHugZmFOwKZAgU5/gpnWR7oHPOSYffhGwmc/+SK/SQ4UDeTFI2c\n' +
-    '40Xw22P8CWbIq4gKi66kSvuFbLSeKQIRMJd50hf7kw3SqnkqEaeRXy5jBovut7CU\n' +
-    'nwcgGPceYmWhKxhkg5urzk+CQZENf+9+pVvArOQemn9bMuaBPwtwXE42+fktQpQ2\n' +
-    'PG3k7ryVL5R0jhuVNXf9ioU2z1ONQ2IdsuFtCKnozfVBAhy9bPfm120rTV/UBOCD\n' +
-    'zcmfRnv081lG9BN/KtZBo7hfFH/ZD2542yVRvibRIIdPWIkTAgMBAAGjUzBRMB0G\n' +
-    'A1UdDgQWBBQ61fQAtAgd7sM/NDtIX4D8GSA/8DAfBgNVHSMEGDAWgBQ61fQAtAgd\n' +
-    '7sM/NDtIX4D8GSA/8DAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IC\n' +
-    'AQCaYh1bxlj9Impoq3rmFHl5/9Fb2o2H2Ne8VjTHb8eSoHuLwXdWzKnw6UhiCaN4\n' +
-    'EZgrsqq1L2Tc8Y+eqT4gz3uDLc5Cj29HHC/suZezIo3lgyZ/A6stYQXE5Gy8e+to\n' +
-    'Qhmf4u8RMZ8zt6i355un6mTJxJq7JxoVqpECf5tg6pMdOUzbcKLTmN6i50jH/PSO\n' +
-    'NQsJhiSJg3caNdWviob+UwEuUineMF/X08dB3gphZ7kmfDeRjmONALMXS1uvPwk2\n' +
-    '3s8S45LmxETx+tcJSvckKRC9JaQf6dgHfKAWHpkIqvLKyqy9Dmvg2RSJi3kI9oaj\n' +
-    'dm64zc6CAsqVaPvoMfWIN7JZq9jvzc8msGiilfhiYoc+M3jvnmM81FuGbAw7Utq4\n' +
-    'uuHtpCcpbxRMChD4WdlrPeBONyBKp+RRWTGfBY1GW5aGWVp/cbcpIc2RSgnZcrxb\n' +
-    '6ef2iTMtUjRd76JlkobTyvgo0GKdLgnr8c711I2YNp+TabKIKZOEvw2X+oGbfxBN\n' +
-    '1WvRB5YJo2rzwZj0fSvN9IwT9TGxSZIo5zcaQuwLEmDZBJShgXN5Ya71Vag1AP2i\n' +
-    'mOwUJRvfTVPWg+wtF2JQwaPpK0+Kb7oCq9tl3PUW40FRgqWV1Tgp6Co/U1W/1BU6\n' +
-    '02Vmic/M/HmRMwWuX1PyVOVr8Mjyj+OMF1JsmdR5eL5Mtg==\n' +
-    '-----END CERTIFICATE-----\n',
+    'scalar.dl.client.tls.ca_root_cert_pem':
+      '-----BEGIN CERTIFICATE-----\n' +
+      'MIIE/jCCAuagAwIBAgIJAJO8tpVEEORLMA0GCSqGSIb3DQEBCwUAMBQxEjAQBgNV\n' +
+      'BAMMCWxvY2FsaG9zdDAeFw0xOTAzMTMxMDUyMTFaFw0yMDAzMTIxMDUyMTFaMBQx\n' +
+      'EjAQBgNVBAMMCWxvY2FsaG9zdDCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoC\n' +
+      'ggIBAKFeFSrXRh5jA+OodMPw0XFO4sd4G9wYERlxgCjDmd9eC+loLpjGwRwwO7os\n' +
+      '/+rhW+Cg/NGhNn64xCmS/JtZf91SBD1QfQ4wk4094sAUIHsztaWtZTATl6aIy0BN\n' +
+      '21A0ueFgVQGehwO1FdRKtS7X+45YV2vMMK/UQ69VSCwY82olBRgWp45TXLUmWVgC\n' +
+      'UAJkE/V2Ch8WLyKpCggtaxYmn8YfzA1X20QDK1b2IW4YPDcPapQLtU6wqIjrXX1E\n' +
+      'w992GgfERm//I14QEyu+qIPafsniDGYxiR6HK8nqeR70QcGHt+Qql24xyjwWHEA/\n' +
+      '43pn3jjrNVRhiVAD8tkVyRmfWjIngksRHPwEh3jG34gshOi9xAaID+mx2AWhThsk\n' +
+      'XbuqSxHckPlvgWHugZmFOwKZAgU5/gpnWR7oHPOSYffhGwmc/+SK/SQ4UDeTFI2c\n' +
+      '40Xw22P8CWbIq4gKi66kSvuFbLSeKQIRMJd50hf7kw3SqnkqEaeRXy5jBovut7CU\n' +
+      'nwcgGPceYmWhKxhkg5urzk+CQZENf+9+pVvArOQemn9bMuaBPwtwXE42+fktQpQ2\n' +
+      'PG3k7ryVL5R0jhuVNXf9ioU2z1ONQ2IdsuFtCKnozfVBAhy9bPfm120rTV/UBOCD\n' +
+      'zcmfRnv081lG9BN/KtZBo7hfFH/ZD2542yVRvibRIIdPWIkTAgMBAAGjUzBRMB0G\n' +
+      'A1UdDgQWBBQ61fQAtAgd7sM/NDtIX4D8GSA/8DAfBgNVHSMEGDAWgBQ61fQAtAgd\n' +
+      '7sM/NDtIX4D8GSA/8DAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IC\n' +
+      'AQCaYh1bxlj9Impoq3rmFHl5/9Fb2o2H2Ne8VjTHb8eSoHuLwXdWzKnw6UhiCaN4\n' +
+      'EZgrsqq1L2Tc8Y+eqT4gz3uDLc5Cj29HHC/suZezIo3lgyZ/A6stYQXE5Gy8e+to\n' +
+      'Qhmf4u8RMZ8zt6i355un6mTJxJq7JxoVqpECf5tg6pMdOUzbcKLTmN6i50jH/PSO\n' +
+      'NQsJhiSJg3caNdWviob+UwEuUineMF/X08dB3gphZ7kmfDeRjmONALMXS1uvPwk2\n' +
+      '3s8S45LmxETx+tcJSvckKRC9JaQf6dgHfKAWHpkIqvLKyqy9Dmvg2RSJi3kI9oaj\n' +
+      'dm64zc6CAsqVaPvoMfWIN7JZq9jvzc8msGiilfhiYoc+M3jvnmM81FuGbAw7Utq4\n' +
+      'uuHtpCcpbxRMChD4WdlrPeBONyBKp+RRWTGfBY1GW5aGWVp/cbcpIc2RSgnZcrxb\n' +
+      '6ef2iTMtUjRd76JlkobTyvgo0GKdLgnr8c711I2YNp+TabKIKZOEvw2X+oGbfxBN\n' +
+      '1WvRB5YJo2rzwZj0fSvN9IwT9TGxSZIo5zcaQuwLEmDZBJShgXN5Ya71Vag1AP2i\n' +
+      'mOwUJRvfTVPWg+wtF2JQwaPpK0+Kb7oCq9tl3PUW40FRgqWV1Tgp6Co/U1W/1BU6\n' +
+      '02Vmic/M/HmRMwWuX1PyVOVr8Mjyj+OMF1JsmdR5eL5Mtg==\n' +
+      '-----END CERTIFICATE-----\n',
   };
 
   describe('Integration test on ClientService', async () => {
@@ -87,7 +89,8 @@ describe('ClientService', () => {
       properties: 'bar',
     };
     const mockedByteContract = new Uint8Array(
-        require('arraybuffer-loader!./StateUpdater.class'));
+        require('arraybuffer-loader!./StateUpdater.class'),
+    );
     const clientService = new ClientService(properties);
     describe('registerCertificate', () => {
       it('should be successful', async () => {
@@ -106,7 +109,9 @@ describe('ClientService', () => {
           const response = await clientService.registerContract(
               mockedContractId,
               mockedContractName,
-              mockedByteContract, contractProperty);
+              mockedByteContract,
+              contractProperty,
+          );
           assert.deepEqual(response, undefined);
         } catch (clientError) {
           assert.fail();
@@ -114,24 +119,31 @@ describe('ClientService', () => {
       });
     });
     describe('executeContract', () => {
-      it('should work as expected when executing a registered contract',
+      it(
+          'should work as expected ' + 'when executing a registered contract',
           async () => {
             try {
               const response = await clientService.executeContract(
                   mockedContractId,
-                  mockedContractArgument, {});
+                  mockedContractArgument,
+                  {},
+              );
               const contractResult = response.getResult();
               assert.equal(contractResult.asset_id, mockedAssetId);
               assert.equal(contractResult.state, mockedState);
-              assert.equal(contractResult.properties,
-                  contractProperty.properties);
+              assert.equal(
+                  contractResult.properties,
+                  contractProperty.properties,
+              );
             } catch (clientError) {
               assert.fail();
             }
-          });
+          },
+      );
     });
     describe('validateLedger linearizably', () => {
-      it('should return successfully and the proofs are the same',
+      it(
+          'should return successfully ' + 'and the proofs are the same',
           async () => {
             await clientService.registerContract(
                 validateLedgerContractId,

--- a/test/signature_validator.test.js
+++ b/test/signature_validator.test.js
@@ -17,10 +17,11 @@ AKtP641f4dGZTV0R6uMYDrZjunwbG+kmt9+vSuE8rjO0
 -----END CERTIFICATE-----
 `;
 
-const privateKey = 'MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0waw' +
-'IBAQQghsSVj9WzmcShUawdnwb2JzFlyxGVPYNwch/EU' +
-'2RmucehRANCAAT9PMYRxgk1zB7l34GU+7G7CIiEyEqky' +
-'lMxkz3gv5tGEM8WficyKBwKKOV7LuqE5/CmVWtO2c0tM0wPza23CdHu';
+const privateKey =
+  'MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0waw' +
+  'IBAQQghsSVj9WzmcShUawdnwb2JzFlyxGVPYNwch/EU' +
+  '2RmucehRANCAAT9PMYRxgk1zB7l34GU+7G7CIiEyEqky' +
+  'lMxkz3gv5tGEM8WficyKBwKKOV7LuqE5/CmVWtO2c0tM0wPza23CdHu';
 
 const {SignatureValidator} = require('../signature_validator.js');
 const jsrsasign = require('jsrsasign');


### PR DESCRIPTION
This PR uses [prettier](https://prettier.io/) to reformat JavaScript files.
Note: They still conform to the ESLint rules.