### PR TITLE
Add notice about the relocation of docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,5 @@
 > [!CAUTION]
-> 
+>
 > The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
 > 
 > To view the ScalarDL documentation, visit [ScalarDL Documentation](https://scalardl.scalar-labs.com/docs/).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,5 @@
 > [!CAUTION]
->
+> 
 > The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
 > 
 > To view the ScalarDL documentation, visit [ScalarDL Documentation](https://scalardl.scalar-labs.com/docs/).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,9 @@
+> [!CAUTION]
+> 
+> The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+> 
+> To view the ScalarDL documentation, visit [ScalarDL Documentation](https://scalardl.scalar-labs.com/docs/).
+
 ## Scalar DL Web Client SDK
 
 This is a library for web applications by which the applications can interact with a [Scalar DL](https://github.com/scalar-labs/scalardl) network.


### PR DESCRIPTION
## Description

This PR adds a cautionary notice to the top of docs in the `docs` folder. Since those docs should now be updated in the [scalar-labs/docs-internal](https://github.com/scalar-labs/docs-internal) repository, the cautionary notice that I've added here is to provide guidance for those who may not know where to update the docs.

## Related issues and/or PRs

- https://github.com/scalar-labs/scalardl/pull/53

## Changes made

- Added a cautionary notice to the top of each doc in the `docs` folder, stating that the doc should be updated in the [scalar-labs/docs-internal](https://github.com/scalar-labs/docs-internal) repository.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

The `docs` folder in this repository can be deleted after we have moved all product docs to the [scalar-labs/docs-internal](https://github.com/scalar-labs/docs-internal) repository and confirmed that the migration was a success.

## Release notes

N/A